### PR TITLE
Add ShellCheck job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ permissions:
   contents: read
 
 jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run ShellCheck
+        run: shellcheck *.sh scripts/*.sh
+
   test:
     name: Test Container Image
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.3
+  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.4
   env:
     INPUT_ARGS: ${{ inputs.args }}
     INPUT_EACH: ${{ inputs.each }}


### PR DESCRIPTION
## Summary
- Adds a ShellCheck job to the CI workflow that lints all shell scripts (`*.sh` and `scripts/*.sh`)
- Uses the shellcheck already installed on `ubuntu-latest` runners
- Bumps version to v1.0.4

## Test plan
- [x] Verify the `shellcheck` job passes in CI
- [x] Verify the `version-check` job passes with the v1.0.4 bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)