### PR TITLE
Run container as root per GitHub Actions requirements

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,9 +17,4 @@ LABEL com.github.actions.name="cosign-exec-action" \
 COPY --from=builder /output/cosign /usr/local/bin/cosign
 COPY --chmod=755 ./entrypoint.sh /entrypoint.sh
 
-RUN groupadd --system actiongroup && \
-    useradd --system --gid actiongroup --no-create-home actionuser
-
-USER actionuser
-
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.5
+  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.6
   env:
     INPUT_ARGS: ${{ inputs.args }}
     INPUT_EACH: ${{ inputs.each }}


### PR DESCRIPTION
## Summary
- Remove custom `actionuser`/`actiongroup` and `USER` directive from Containerfile
- GitHub Actions [requires](https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user) Docker container actions to run as root
- The non-root user caused `mkdir /github/home/.sigstore: permission denied` when cosign tried to initialize its TUF cache during image signing
- Bump to v1.0.6

## Test plan
- [x] Local `podman build` and `podman run` succeed
- [x] CI tests pass
- [ ] CD signing step succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)