### PR TITLE
Copy CA certificates into runtime image for TLS verification

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,6 +14,7 @@ LABEL com.github.actions.name="cosign-exec-action" \
     org.opencontainers.image.documentation="https://github.com/samhclark/cosign-exec-action" \
     org.opencontainers.image.description="A simple wrapper around the cosign executable for use as a step in GitHub Actions"
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /output/cosign /usr/local/bin/cosign
 COPY --chmod=755 ./entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.6
+  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.7
   env:
     INPUT_ARGS: ${{ inputs.args }}
     INPUT_EACH: ${{ inputs.each }}


### PR DESCRIPTION
## Summary
- Copy `/etc/ssl/certs/ca-certificates.crt` from the golang builder stage into the slim Debian runtime image
- Fixes `x509: certificate signed by unknown authority` error when cosign connects to Sigstore's TUF repository for keyless signing
- Bump to v1.0.7

## Test plan
- [x] Verified CA bundle exists in golang image as a single concatenated PEM
- [x] Local `podman build` and `podman run` succeed
- [ ] CI tests pass
- [ ] CD signing step succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)