### PR TITLE
Use podman push --digestfile to capture registry digest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,11 +70,12 @@ jobs:
             podman tag "$primary" "${image}:${tag}"
           done
 
-          for tag in "${tags[@]}"; do
+          podman push --digestfile=/tmp/digest "$primary"
+          for tag in "${tags[@]:1}"; do
             podman push "${image}:${tag}"
           done
 
-          digest=$(podman inspect --format '{{.Digest}}' "$primary" | sed 's/sha256://')
+          digest=$(sed 's/sha256://' /tmp/digest)
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Sign Container Image

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.7
+  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.8
   env:
     INPUT_ARGS: ${{ inputs.args }}
     INPUT_EACH: ${{ inputs.each }}


### PR DESCRIPTION
## Summary
- Replace `podman inspect --format '{{.Digest}}'` with `podman push --digestfile` to capture the registry manifest digest
- `podman inspect` returns the local image digest, which differs from the registry's manifest digest — cosign got a 404 trying to sign the wrong digest
- Push the primary tag with `--digestfile`, then push remaining tags normally
- Bump to v1.0.8

## Test plan
- [x] Verified with `skopeo inspect` that registry digest (`f97b0a2f...`) differs from local digest (`4e1dd1c0...`)
- [ ] CI tests pass
- [ ] CD signing step succeeds after merge
- [ ] Verify signature: `cosign verify ghcr.io/samhclark/cosign-exec-action:v1.0.8 --certificate-identity-regexp='https://github.com/samhclark/cosign-exec-action' --certificate-oidc-issuer='https://token.actions.githubusercontent.com'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)