### PR TITLE
Fix `github` context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,48 @@ jobs:
       - name: Run ShellCheck
         run: shellcheck *.sh scripts/*.sh
 
+  validate-action:
+    name: Validate action.yml
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check runs.env only references inputs context
+        run: |
+          # Extract the runs.env block and check for non-inputs contexts.
+          # Container actions only have access to the inputs context in runs.env.
+          # See: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsenvenvironment-variable
+          in_env=false
+          found=0
+          while IFS= read -r line; do
+            case "$line" in
+              "  env:") in_env=true; continue ;;
+            esac
+            if $in_env; then
+              # Stop at next top-level key (not indented with spaces)
+              if printf '%s' "$line" | grep -qP '^\S'; then
+                break
+              fi
+              # Extract the expression body (between ${{ and }}) and check
+              # for any word.word pattern that isn't inputs.something
+              inner=$(printf '%s' "$line" | grep -oP '\$\{\{\s*\K[^}]+' || true)
+              if [ -n "$inner" ]; then
+                bad=$(printf '%s' "$inner" | grep -oP '\b(?!inputs\.)\w+\.\w+' || true)
+                if [ -n "$bad" ]; then
+                  echo "::error::runs.env references disallowed context '$bad': $line"
+                  echo "Container actions only support the 'inputs' context in runs.env"
+                  found=$((found + 1))
+                fi
+              fi
+            fi
+          done < action.yml
+          if [ "$found" -gt 0 ]; then
+            exit 1
+          fi
+          echo "All runs.env expressions only reference inputs context"
+
   test:
     name: Test Container Image
     runs-on: ubuntu-latest
@@ -89,5 +131,24 @@ jobs:
           count=$(echo "$output" | grep -c "\"gitVersion\": \"v${{ steps.expected.outputs.version }}\"")
           if [ "$count" -ne 1 ]; then
             echo "::error::Expected 1 version line, got $count (trailing newline bug)"
+            exit 1
+          fi
+
+      - name: Test - Registry Username Defaults to GITHUB_REPOSITORY_OWNER
+        run: |
+          # When INPUT_REGISTRY_USERNAME is empty and INPUT_REGISTRY_TOKEN is set,
+          # the entrypoint should default to GITHUB_REPOSITORY_OWNER.
+          # cosign login will fail (fake token), but we can check the error message
+          # includes the expected username.
+          output=$(podman run --rm \
+            --env INPUT_ARGS=version \
+            --env INPUT_REGISTRY=ghcr.io \
+            --env INPUT_REGISTRY_USERNAME= \
+            --env INPUT_REGISTRY_TOKEN=fake-token \
+            --env GITHUB_REPOSITORY_OWNER=test-owner \
+            cosign-exec-action:test 2>&1 || true)
+          echo "$output"
+          if ! echo "$output" | grep -q "test-owner"; then
+            echo "::error::Expected registry login to use GITHUB_REPOSITORY_OWNER (test-owner)"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ rather than built on every action run.
 | `args` | yes | `version` | Arguments passed to `cosign` |
 | `each` | no | — | Newline-separated list of values. Each line is substituted for `{}` in `args` and `cosign` is called once per line. `args` must contain `{}` when `each` is set. |
 | `registry` | no | `ghcr.io` | Container registry hostname to authenticate to. Required when `registry-token` is set. |
-| `registry-username` | no | `github.repository_owner` | Username for registry authentication. |
+| `registry-username` | no | `GITHUB_REPOSITORY_OWNER` | Username for registry authentication. Defaults to the repository owner via the `GITHUB_REPOSITORY_OWNER` environment variable provided by GitHub Actions. |
 | `registry-token` | no | — | Token for authenticating to the container registry. If set, runs `cosign login` before the main command. |
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ inputs:
 
 runs:
   using: docker
-  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.14
+  image: docker://ghcr.io/samhclark/cosign-exec-action:v1.0.15
   env:
     INPUT_ARGS: ${{ inputs.args }}
     INPUT_EACH: ${{ inputs.each }}
     INPUT_REGISTRY: ${{ inputs.registry }}
-    INPUT_REGISTRY_USERNAME: ${{ inputs.registry-username || github.repository_owner }}
+    INPUT_REGISTRY_USERNAME: ${{ inputs.registry-username }}
     INPUT_REGISTRY_TOKEN: ${{ inputs.registry-token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@
 set -e
 
 if [ -n "${INPUT_REGISTRY_TOKEN}" ]; then
+    INPUT_REGISTRY_USERNAME="${INPUT_REGISTRY_USERNAME:-${GITHUB_REPOSITORY_OWNER}}"
     echo "${INPUT_REGISTRY_TOKEN}" | cosign login "${INPUT_REGISTRY}" --username="${INPUT_REGISTRY_USERNAME}" --password-stdin
 fi
 


### PR DESCRIPTION
Trying to fix an error I saw in `custom-coreos` which doesn't provide a repository owner, so tried to fall back to the `{{github.repository_owner}}` var which failed in GHA. 

Hoping this works instead? 