### PR TITLE
Make cosign updater a GitHub App

### DIFF
--- a/.github/workflows/update-cosign.yml
+++ b/.github/workflows/update-cosign.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check-update:
     runs-on: ubuntu-latest
+    environment: cosign-updater
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,10 +30,18 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate app token
+        if: steps.changes.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.COSIGN_UPDATER_APP_ID }}
+          private-key: ${{ secrets.COSIGN_UPDATER_PRIVATE_KEY }}
+
       - name: Create or update PR
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           new_tag=$(grep '^tag=' build-cosign.sh | cut -d'"' -f2)
           branch="update-cosign-${new_tag}"


### PR DESCRIPTION
This way I don't need to broadly allow all workflows to create and approve PRs.